### PR TITLE
Add QR Code scan to share button that redirects to OID4VP flow

### DIFF
--- a/Targets/AppUIKit/Sources/ContentView.swift
+++ b/Targets/AppUIKit/Sources/ContentView.swift
@@ -4,7 +4,7 @@ public struct ContentView: View {
     @State var path: NavigationPath = .init()
 
     public init() {}
-    
+
     func handleSpruceIDUrl(url: URL) {
         let query = URLComponents(string: url.absoluteString)?
             .queryItems?
@@ -13,13 +13,13 @@ public struct ContentView: View {
                     $0.name == "sd-jwt"
                 }
             )?.value
-        if(query != nil) {
+        if query != nil {
             self.path.append(
                 AddToWallet(rawCredential: query!)
             )
         }
     }
-    
+
     func handleOid4vpUrl(url: URL) {
         // @TODO: integrate with OID4VP flow
     }
@@ -59,11 +59,14 @@ public struct ContentView: View {
                             rawCredential: addToWalletParams.rawCredential
                         )
                     }
+                    .navigationDestination(for: ScanOID4VP.self) { _ in
+                        ScanOID4VPQR(path: $path)
+                    }
             }
         }
         .onOpenURL { url in
             let scheme = url.scheme
-            
+
             switch scheme {
             case "spruceid":
                 handleSpruceIDUrl(url: url)
@@ -77,9 +80,9 @@ public struct ContentView: View {
 }
 
 extension UIScreen {
-   static let screenWidth = UIScreen.main.bounds.size.width
-   static let screenHeight = UIScreen.main.bounds.size.height
-   static let screenSize = UIScreen.main.bounds.size
+    static let screenWidth = UIScreen.main.bounds.size.width
+    static let screenHeight = UIScreen.main.bounds.size.height
+    static let screenSize = UIScreen.main.bounds.size
 }
 
 #Preview {

--- a/Targets/AppUIKit/Sources/wallet/ScanOID4VPQR.swift
+++ b/Targets/AppUIKit/Sources/wallet/ScanOID4VPQR.swift
@@ -1,0 +1,35 @@
+import SpruceIDMobileSdkRs
+import SwiftUI
+
+struct ScanOID4VP: Hashable {}
+
+struct ScanOID4VPQR: View {
+
+    @State var success: Bool?
+
+    @Binding var path: NavigationPath
+
+    var body: some View {
+        ScanningComponent(
+            path: $path,
+            scanningParams: Scanning(
+                scanningType: .qrcode,
+                onCancel: {
+                    path.removeLast()
+                },
+                onRead: { code in
+                    Task {
+                        do {
+                            // TODO: Add other checks as necessary for
+                            // validating OID4VP url and handle OID4VP flow
+                            success = true
+                        } catch {
+                            success = false
+                            print(error)
+                        }
+                    }
+                }
+            )
+        )
+    }
+}

--- a/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
+++ b/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
@@ -40,29 +40,61 @@ struct WalletHomeHeader: View {
 
 struct WalletHomeBody: View {
     @Binding var path: NavigationPath
-    
+
     @State var credentials: [Credential] = []
 
     var body: some View {
         ZStack {
-            if(!credentials.isEmpty) {
-                ScrollView(.vertical, showsIndicators: false) {
-                    Section {
-                        ForEach(credentials, id: \.self.id) { credential in
-                            AchievementCredentialItem(
-                                rawCredential: credential.rawCredential,
-                                onDelete: {
-                                    _ = CredentialDataStore.shared.delete(id: credential.id)
-                                    self.credentials = CredentialDataStore.shared.getAllCredentials()
-                                }
-                            )
+            if !credentials.isEmpty {
+                ZStack {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        Section {
+                            ForEach(credentials, id: \.self.id) { credential in
+                                AchievementCredentialItem(
+                                    rawCredential: credential.rawCredential,
+                                    onDelete: {
+                                        _ = CredentialDataStore.shared.delete(id: credential.id)
+                                        self.credentials = CredentialDataStore.shared
+                                            .getAllCredentials()
+                                    }
+                                )
+                            }
+                            //                    ForEach(vcs, id: \.self) { vc in
+                            //                        GenericCredentialListItem(vc: vc)
+                            //                    }
+                            //                    ShareableCredentialListItem(mdoc: mdocBase64)
                         }
-                        //                    ForEach(vcs, id: \.self) { vc in
-                        //                        GenericCredentialListItem(vc: vc)
-                        //                    }
-                        //                    ShareableCredentialListItem(mdoc: mdocBase64)
+                        .padding(.bottom, 50)
                     }
-                    .padding(.bottom, 50)
+                    .padding(.top, 20)
+
+                    VStack {
+                        Spacer()
+                        Button(action: {
+                            path.append(ScanOID4VP())
+                        }) {
+                            HStack {
+                                Image("QRCodeReader")  // Ensure image is added to assets
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 24, height: 24)  // Adjust size as needed
+                                    .foregroundColor(.white)
+                                Text("Scan to share")
+                                    .font(.system(size: 15))
+                                    .fontWeight(.regular)
+                                    .foregroundColor(.white)
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                Color(
+                                    UIColor(
+                                        red: 72 / 255, green: 140 / 255, blue: 244 / 255, alpha: 1))
+                            )
+                            .cornerRadius(8)
+                        }
+                        .padding()
+                    }
                 }
             } else {
                 VStack {
@@ -73,31 +105,31 @@ struct WalletHomeBody: View {
                     Spacer()
                 }
             }
-//            VStack {
-//                Spacer()
-//                Button{
-//                    path.append(Scanning(scanningType: .qrcode))
-//                } label: {
-//                    HStack(alignment: .center, spacing: 10) {
-//                        Image("QRCodeReader")
-//                            .resizable()
-//                            .frame(width: CGFloat(18), height: CGFloat(18))
-//                            .foregroundColor(.scanButton)
-//                        Text("Scan to share")
-//                            .font(.customFont(font: .inter, style: .medium, size: .h4))
-//                    }
-//                    .foregroundStyle(.white)
-//                    .padding(.vertical, 13)
-//                    .frame(width: UIScreen.screenWidth - 40)
-//                    .background(.scanButton)
-//                    .cornerRadius(100)
-//                    .overlay(
-//                        RoundedRectangle(cornerRadius: 100)
-//                            .stroke(.scanButton, lineWidth: 2)
-//                    )
-//                    .padding(.bottom, 6)
-//                }
-//            }
+            //            VStack {
+            //                Spacer()
+            //                Button{
+            //                    path.append(Scanning(scanningType: .qrcode))
+            //                } label: {
+            //                    HStack(alignment: .center, spacing: 10) {
+            //                        Image("QRCodeReader")
+            //                            .resizable()
+            //                            .frame(width: CGFloat(18), height: CGFloat(18))
+            //                            .foregroundColor(.scanButton)
+            //                        Text("Scan to share")
+            //                            .font(.customFont(font: .inter, style: .medium, size: .h4))
+            //                    }
+            //                    .foregroundStyle(.white)
+            //                    .padding(.vertical, 13)
+            //                    .frame(width: UIScreen.screenWidth - 40)
+            //                    .background(.scanButton)
+            //                    .cornerRadius(100)
+            //                    .overlay(
+            //                        RoundedRectangle(cornerRadius: 100)
+            //                            .stroke(.scanButton, lineWidth: 2)
+            //                    )
+            //                    .padding(.bottom, 6)
+            //                }
+            //            }
         }
         .onAppear(perform: {
             self.credentials = CredentialDataStore.shared.getAllCredentials()


### PR DESCRIPTION
This PR adds a button to the wallet home view (if there are any `rawCredentials` on the screen) which redirects to the OID4vp flow. The button will not appear if there are no credentials added yet.

Note: This is the iOS version of this PR: https://github.com/spruceid/mobile-sdk-kt/pull/34