### PR TITLE
Rename app sections

### DIFF
--- a/Targets/AppUIKit/Sources/verifier/VerifierHomeView.swift
+++ b/Targets/AppUIKit/Sources/verifier/VerifierHomeView.swift
@@ -17,8 +17,8 @@ struct VerifierHomeHeader: View {
 
     var body: some View {
         HStack {
-            Text("Spruce Verifier")
-                .font(.customFont(font: .inter, style: .bold, size: .h0))
+            Text("SpruceKit Demo Verifier")
+                .font(.customFont(font: .inter, style: .bold, size: .h2))
                 .padding(.leading, 36)
                 .foregroundStyle(Color("TextHeader"))
             Spacer()

--- a/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
+++ b/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
@@ -17,8 +17,8 @@ struct WalletHomeHeader: View {
 
     var body: some View {
         HStack {
-            Text("Spruce Wallet")
-                .font(.customFont(font: .inter, style: .bold, size: .h0))
+            Text("SpruceKit Demo Wallet")
+                .font(.customFont(font: .inter, style: .bold, size: .h2))
                 .padding(.leading, 36)
                 .foregroundStyle(Color("TextHeader"))
             Spacer()


### PR DESCRIPTION
This renames the wallet section to "SpruceKit Demo Wallet" and the verifier section to "SpruceKit Demo Verifier".