### PR TITLE
Add error case for QR scanning an invalid verification request

### DIFF
--- a/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
+++ b/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
@@ -17,7 +17,7 @@ struct DispatchQRView: View {
             do {
                 print("DISPLAYING CREDENTIAL REQUEST")
                 print(verificationRequestOffer)
-                if verificationRequestOffer.hasPrefix("openid://") {
+                if verificationRequestOffer.hasPrefix("openid4vp://") {
                     // TODO: Implement OID4VP flow for credential request from user
                 } else {
                     print(

--- a/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
+++ b/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
@@ -18,10 +18,11 @@ struct DispatchQRView: View {
                 print("DISPLAYING CREDENTIAL REQUEST")
                 print(verificationRequestOffer)
                 if verificationRequestOffer.hasPrefix("openid4vp://") {
-                    // TODO: Implement OID4VP flow for credential request from user
+                    // TODO for Joey: Implement OID4VP flow for verification request from user
                 } else {
                     print(
                         "The QR code you have scanned is not recognized as a verification request")
+                    // TODO for Juliano: Add UI component for "QR not recognized" error screen
                 }
                 loading = false
             }

--- a/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
+++ b/Targets/AppUIKit/Sources/wallet/DispatchQRView.swift
@@ -4,33 +4,63 @@ import SwiftUI
 struct DispatchQR: Hashable {}
 
 struct DispatchQRView: View {
-
+    @State var loading: Bool = false
+    @State var verificationRequest: String?
+    @State var err: String?
     @State var success: Bool?
 
     @Binding var path: NavigationPath
 
-    var body: some View {
-        ScanningComponent(
-            path: $path,
-            scanningParams: Scanning(
-                scanningType: .qrcode,
-                onCancel: {
-                    path.removeLast()
-                },
-                onRead: { code in
-                    Task {
-                        do {
-                            // TODO: Add other checks as necessary for
-                            // validating OID4VP url and handle OID4VP flow
-                            // try await dispatchQRcode(jwtVp: code)
-                            success = true
-                        } catch {
-                            success = false
-                            print(error)
-                        }
-                    }
+    func getVerificationRequest(verificationRequestOffer: String) {
+        loading = true
+        Task {
+            do {
+                print("DISPLAYING CREDENTIAL REQUEST")
+                print(verificationRequestOffer)
+                if verificationRequestOffer.hasPrefix("openid://") {
+                    // TODO: Implement OID4VP flow for credential request from user
+                } else {
+                    print(
+                        "The QR code you have scanned is not recognized as a verification request")
                 }
-            )
-        )
+                loading = false
+            }
+        }
+    }
+
+    var body: some View {
+        VStack {
+            if loading {
+                VStack {
+                    Text("Loading...")
+                }
+            } else if err != nil {
+                VStack {
+                    Text(err!)
+                }
+            } else if verificationRequest == nil {
+                VStack {
+                    ScanningComponent(
+                        path: $path,
+                        scanningParams: Scanning(
+                            title: "Scan to Share Credential",
+                            scanningType: .qrcode,
+                            onCancel: {
+                                path.removeLast()
+                            },
+                            onRead: { code in
+                                getVerificationRequest(verificationRequestOffer: code)
+                            }
+                        )
+                    )
+                    Text("Reading...")
+                }
+            } else {
+                VStack {
+                    // TODO: validate one of the user credentials against the request
+                    Text(verificationRequest!)
+                }
+            }
+        }
     }
 }

--- a/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
+++ b/Targets/AppUIKit/Sources/wallet/WalletHomeView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import SpruceIDMobileSdk
 import SpruceIDMobileSdkRs
+import SwiftUI
 
 struct WalletHomeView: View {
     @Binding var path: NavigationPath
@@ -15,15 +15,16 @@ struct WalletHomeView: View {
 }
 
 extension Data {
-  var base64EncodedUrlSafe: String {
-    let string = self.base64EncodedString()
+    var base64EncodedUrlSafe: String {
+        let string = self.base64EncodedString()
 
-    // Make this URL safe and remove padding
-    return string
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-  }
+        // Make this URL safe and remove padding
+        return
+            string
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
 }
 
 struct WalletHomeHeader: View {


### PR DESCRIPTION
This PR adds a check to make sure the "scan to share" QR scan actually scans a QR with the right prefix. After this check is passed we can put the scanned url through the OID4VP flow to verify the user's credential against the request.